### PR TITLE
Use same renovate config as other Anbox repos

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,10 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":disableDependencyDashboard",
-    "schedule:earlyMondays",
-    ":combinePatchMinorReleases",
     ":ignoreUnstable",
-    "helpers:pinGitHubActionDigests"
+    "group:allNonMajor"
+  ],
+  "packageRules": [
+    {
+      "groupName": "GitHub actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor",
+        "major"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Use the same renovate config as the other repos, where GitHub actions are pinned to specific hashes and follow Semver and we get a single PR for all GH action updates.