### PR TITLE
Disable go-related renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,12 @@
         "minor",
         "major"
       ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
These updates should not be applied on the SDK repo directly, but should instead be applied on the AMS codebase and reflected here.